### PR TITLE
Make infosquito2 make an additional temp table for performance

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,6 +181,7 @@ func handlePrefix(del amqp.Delivery, db *ICATConnection, es *ESConnection, publi
 		log.Infof("Prefix %s too large, splitting", prefix)
 		return publishPrefixMessages(splitPrefix(prefix), publishClient, del)
 	} else if err != nil {
+		log.Errorf("Error reindexing prefix %s: %s", prefix, err)
 		rejectErr := del.Reject(!del.Redelivered)
 		if rejectErr != nil {
 			log.Error(rejectErr)


### PR DESCRIPTION
I noticed infosquito2 was being really slow in prod and dug into it. The prior object_uuids temporary table creation was what was taking ages, and it seems it was sequential-scanning the r_objt_metamap table. Upon experimentation, splitting that table creation into an initial "base" UUIDs table followed by a second query using the base table to create the object_uuids worked much better since the planner has better information to use for the join in that case (and also, it'd catch too-large prefixes earlier). I'd love to get this out and into prod ASAP, since infosquito2 is having trouble keeping up and this speeds it up very dramatically (a couple seconds rather than a couple minutes).