### PR TITLE
Re-integrate cyverse metadata in prefix indexing

### DIFF
--- a/reindex.go
+++ b/reindex.go
@@ -403,10 +403,6 @@ func ReindexPrefix(context context.Context, icat *ICATConnection, dedb *DEDBConn
 	}
 	defer deRollback()
 
-	// probably fetch metadata around here and create a lookup object of
-	// some sort to pass to the process* functions -- possibly in a
-	// goroutine? we shouldn't need it until after the temp tables are made
-	// in the ICAT
 	avusRows, err := deTx.GetAVUs(ctx, prefix)
 	if err != nil {
 		return err

--- a/reindex.go
+++ b/reindex.go
@@ -414,6 +414,9 @@ func ReindexPrefix(context context.Context, icat *ICATConnection, dedb *DEDBConn
 	defer avusRows.Close()
 
 	avus, err := preprocessMetadata(avusRows)
+	if err != nil {
+		return err
+	}
 	avusRows.Close()
 	deRollback()
 


### PR DESCRIPTION
Since we added config for the metadata DB already, for tags, this change makes it so when a prefix is being indexed, we fetch CyVerse metadata that matches the same prefix and, when present, integrate it before classifying and indexing documents.

I'm hoping this won't hurt performance too terribly -- in the past, at least, interactions with ES were by far the worst offender for performance, where this is adding an extra database connection & query, an extra JSON marshalling at the end, and potentially an extra unmarshalling. We'll probably just have to look at it in production to see if the difference matters at all; we could still avoid the re-marshalling for objects without metadata if the difference is at all relevant, but I kinda doubt it.